### PR TITLE
Docker: Use a smaller runtime image and publish as trimmed SingleFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY Engine/*.csproj ./Engine/
 COPY SharedApplication/*.csproj ./SharedApplication/
 COPY Textrude/*.csproj ./Textrude/
+COPY ScriptLibrary/*.csproj ./ScriptLibrary/
 RUN dotnet restore Textrude
 
 COPY . ./
@@ -11,9 +12,9 @@ COPY . ./
 # A newer version seems to be installed - closer investigation needed
 # (Of course currently this CANNOT work because of no local git clone)
 ENV DisableGitVersionTask=true
-RUN dotnet publish Textrude -c Release -o out
+RUN dotnet publish Textrude -c Release -o out -r linux-musl-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine3.12
 WORKDIR /app
 COPY --from=builder /app/out .
-ENTRYPOINT ["dotnet", "Textrude.dll"]
+ENTRYPOINT ["/app/Textrude"]


### PR DESCRIPTION
Instead of using a full .NET runtime to run the Textrude app, use a smaller image, which only contains the runtime dependencies for .NET apps compiled for a specific runtime

Decreases the image size (from `dev_old` to `dev`):
```
> docker image ls textrude
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
textrude     dev_old   5e16cbecc7cf   2 minutes ago   189MB
textrude     dev       733be3734be0   8 minutes ago   43.2MB
```